### PR TITLE
feat: enhance Dockerfile for Playwright and add font support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,26 @@ FROM node:lts-alpine
 
 WORKDIR /app
 
+# Install system dependencies for Playwright and font support
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    fontconfig \
+    font-noto-cjk
+
+# Tell Playwright to use the installed Chromium
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 # Copy package files
 COPY package*.json ./
 
 # Install dependencies
 RUN npm install --ignore-scripts
+
+# Manually install Playwright Node.js bindings without browsers (we use system chromium)
+RUN npx playwright install-deps || true
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
- Install system dependencies for Playwright including Chromium and font packages.
- Configure Playwright to use the installed Chromium in Docker.
- Add a function to set the font family for Mermaid diagrams, supporting custom overrides and ensuring Chinese font compatibility.