### PR TITLE
feat(cli): add --host option and bind host for SSE/streamable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,11 @@ const { values } = parseArgs({
       short: "p",
       default: "3033",
     },
+    host: {
+      type: "string",
+      short: "H",
+      default: "",
+    },
     endpoint: {
       type: "string",
       short: "e",
@@ -39,6 +44,7 @@ MCP Mermaid CLI
 Options:
   --transport, -t  Specify the transport protocol: "stdio", "sse", or "streamable" (default: "stdio")
   --port, -p       Specify the port for SSE or streamable transport (default: 3033)
+  --host, -H       Specify the host to bind (e.g., 0.0.0.0)
   --endpoint, -e   Specify the endpoint for the transport:
                    - For SSE: default is "/sse"
                    - For streamable: default is "/mcp"
@@ -54,12 +60,14 @@ if (transport === "sse") {
   const port = Number.parseInt(values.port as string, 10);
   // Use provided endpoint or default to "/sse" for SSE
   const endpoint = values.endpoint || "/sse";
-  runSSEServer(endpoint, port).catch(console.error);
+  const host = (values.host as string) || undefined;
+  runSSEServer(endpoint, port, host).catch(console.error);
 } else if (transport === "streamable") {
   const port = Number.parseInt(values.port as string, 10);
   // Use provided endpoint or default to "/mcp" for streamable
   const endpoint = values.endpoint || "/mcp";
-  runHTTPStreamableServer(endpoint, port).catch(console.error);
+  const host = (values.host as string) || undefined;
+  runHTTPStreamableServer(endpoint, port, host).catch(console.error);
 } else {
   runStdioServer().catch(console.error);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -125,9 +125,10 @@ export async function runStdioServer(): Promise<void> {
 export async function runSSEServer(
   endpoint = "/sse",
   port = 3033,
+  host?: string,
 ): Promise<void> {
   const server = createServer();
-  await startSSEMcpServer(server, endpoint, port);
+  await startSSEMcpServer(server, endpoint, port, host);
 }
 
 /**
@@ -136,6 +137,7 @@ export async function runSSEServer(
 export async function runHTTPStreamableServer(
   endpoint = "/mcp",
   port = 3033,
+  host?: string,
 ): Promise<void> {
-  await startHTTPStreamableServer(createServer, endpoint, port);
+  await startHTTPStreamableServer(createServer, endpoint, port, host);
 }

--- a/src/services/sse.ts
+++ b/src/services/sse.ts
@@ -7,6 +7,7 @@ export const startSSEMcpServer = async (
   server: Server,
   endpoint = "/sse",
   port = 3033,
+  host?: string,
 ): Promise<void> => {
   const app = express();
   app.use(express.json());
@@ -39,7 +40,12 @@ export const startSSEMcpServer = async (
     }
   });
 
-  app.listen(port, () => {
-    console.log(`SSE Server listening on http://localhost:${port}${endpoint}`);
-  });
+  const cb = () => {
+    const shownHost = host || "localhost";
+    console.log(
+      `SSE Server listening on http://${shownHost}:${port}${endpoint}`,
+    );
+  };
+  if (host) app.listen(port, host, cb);
+  else app.listen(port, cb);
 };

--- a/src/services/streamable.ts
+++ b/src/services/streamable.ts
@@ -8,6 +8,7 @@ export const startHTTPStreamableServer = async (
   createServer: () => Server,
   endpoint = "/mcp",
   port = 1122,
+  host?: string,
 ): Promise<void> => {
   const app = express();
   app.use(express.json());
@@ -52,9 +53,12 @@ export const startHTTPStreamableServer = async (
     });
   });
 
-  app.listen(port, () => {
+  const cb = () => {
+    const shownHost = host || "localhost";
     console.log(
-      `Streamable HTTP Server listening on http://localhost:${port}${endpoint}`,
+      `Streamable HTTP Server listening on http://${shownHost}:${port}${endpoint}`,
     );
-  });
+  };
+  if (host) app.listen(port, host, cb);
+  else app.listen(port, cb);
 };


### PR DESCRIPTION
- Add --host/-H CLI flag and plumb through index -> server -> services
- Support explicit host binding via Express (app.listen(port, host))
- Improve startup logs to show actual host