### PR TITLE
fix: #22 Dockerfile fixed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm install \
-    && npm run build \
-    && npx playwright install --with-deps chromium \
-    && apt-get clean \
-    && npm prune --omit=dev \
-    && npm cache clean --force \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/cache/apt/*
+RUN npm install --ignore-scripts \
+&& npm run build \
+&& npx playwright install --with-deps chromium \
+&& apt-get clean \
+&& npm prune --omit=dev \
+&& npm cache clean --force \
+&& rm -rf /var/lib/apt/lists/* \
+&& rm -rf /var/cache/apt/*
 
-CMD ["node", "build/index.js"]
+ENTRYPOINT ["node", "build/index.js"]


### PR DESCRIPTION
**Fixes: ** #22 

The problem occurred because `npm install` triggers the `postinstall` script, which tries to run playwright install, but this can fail in the Docker build context. The fix is to skip `postinstall` scripts during the initial install using `--ignore-scripts`, then explicitly run the Playwright install afterward.
