### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,8 @@ docker run -p 1122:1122 susuperli/mcp-mermaid:latest --transport streamable --po
 ## 📄 License
 
 MIT@[hustcc](https://github.com/hustcc).
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hustcc-mcp-mermaid).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hustcc-mcp-mermaid).